### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/infotools/numbertools/_scale.py
+++ b/infotools/numbertools/_scale.py
@@ -2,7 +2,7 @@ import math
 from dataclasses import dataclass, field
 from typing import List, Optional, SupportsAbs
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 @dataclass

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
 		"Programming Language :: Python :: 3",
 		"License :: OSI Approved :: MIT License",
 		"Operating System :: OS Independent",
-	], install_requires = ['pendulum', 'fuzzywuzzy', 'loguru', 'psutil', 'pandas', 'tqdm'],
+	], install_requires = ['pendulum', 'rapidfuzz', 'loguru', 'psutil', 'pandas', 'tqdm'],
 	tests_requires = ['pytest']
 )


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.